### PR TITLE
Update google-sheets-sync.md with deprecation notice

### DIFF
--- a/docs/content/en/integrations/google-sheets-sync.md
+++ b/docs/content/en/integrations/google-sheets-sync.md
@@ -5,6 +5,7 @@ draft: false
 weight: 7
 ---
 
+**Please note - the Google Sheets feature has been deprecated as of DefectDojo version 2.21.0 - these documents are for reference only.**
 
 With the Google Sheets sync feature, DefectDojo allow the users to
 export all the finding details of each test into a separate Google


### PR DESCRIPTION
The Google Sheets sync feature was removed in March 2023 - this change adds a notice to documentation to reflect that.

See: https://github.com/DefectDojo/django-DefectDojo/pull/7889
