### PR TITLE
correct API help text: endpoint_to_add

### DIFF
--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -2064,7 +2064,7 @@ class ImportScanSerializer(serializers.Serializer):
         queryset=Endpoint.objects.all(),
         required=False,
         default=None,
-        help_text="The IP address, host name or full URL. It must be valid",
+        help_text="Enter the ID of an Endpoint that is associated with the target Product. New Findings will be added to that Endpoint."
     )
     file = serializers.FileField(allow_empty_file=True, required=False)
     product_type_name = serializers.CharField(required=False)

--- a/dojo/api_v2/serializers.py
+++ b/dojo/api_v2/serializers.py
@@ -2331,7 +2331,10 @@ class ReImportScanSerializer(TaggitSerializer, serializers.Serializer):
         choices=get_choices_sorted(), required=True
     )
     endpoint_to_add = serializers.PrimaryKeyRelatedField(
-        queryset=Endpoint.objects.all(), default=None, required=False
+        queryset=Endpoint.objects.all(),
+        required=False,
+        default=None,
+        help_text="Enter the ID of an Endpoint that is associated with the target Product. New Findings will be added to that Endpoint."
     )
     file = serializers.FileField(allow_empty_file=True, required=False)
     product_type_name = serializers.CharField(required=False)


### PR DESCRIPTION
The `endpoint_to_add` option on `POST /import` is incorrectly described in the API docs:

<img width="512" alt="Screenshot 2024-07-17 at 5 11 02 PM" src="https://github.com/user-attachments/assets/0b5f9c7a-ed91-4e8d-8cc9-b8b611d5fac6">

Helptext says that this field allows you to add a new Endpoint, but this is inaccurate.  Instead, this method looks for an existing Endpoint ID in the database and associates it with the incoming Findings.

I am changing the help text so that it is described accurately.  I am also reflecting the help text to`/reimport` because this method works in the same way on that endpoint.

- Tested /import endpoint for accuracy
- Tested /reimport endpoint for accuracy